### PR TITLE
Center vertically in a square container

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ props: {
     type: Boolean,
     default: () => false
   },
+  square: { // should the video be centered vertically in a square container
+    type: Boolean,
+    default: () => false
+  },
   controls: { // show video playback controls
     type: Boolean,
     default: () => false

--- a/src/CanvasVideo.js
+++ b/src/CanvasVideo.js
@@ -191,9 +191,11 @@ export default {
   },
   computed: {
     computedWrapStyles () {
-      return (this.cover)
+      const styles = (this.cover)
         ? Object.assign({}, videoWrapInnerStyles, mediaCoveringStyles)
-        : { paddingBottom: `${this.aspectRatio * 100}%`, marginTop: `${(1 - this.aspectRatio) / 2 * 100}%`, ...videoWrapInnerStyles }
+        : { paddingBottom: `${this.aspectRatio * 100}%`, ...videoWrapInnerStyles }
+      if (this.square) styles.marginTop = `${(1 - this.aspectRatio) / 2 * 100}%`
+      return styles
     },
     computedVideoStyles () {
       const cover = Object.assign({}, videoStyles, mediaCoveringStyles)
@@ -228,6 +230,10 @@ export default {
       default: () => false
     },
     autoplay: {
+      type: Boolean,
+      default: () => false
+    },
+    square: {
       type: Boolean,
       default: () => false
     },

--- a/src/CanvasVideo.js
+++ b/src/CanvasVideo.js
@@ -77,7 +77,7 @@ export default {
     return {
       playing: false,
       scrubbing: false,
-      aspectRatioPercentage: '',
+      aspectRatio: 1,
       duration: 0,
       elapsed: 0,
       lastTime: 0,
@@ -115,7 +115,7 @@ export default {
       const { video } = this.$refs
       this.width = video.videoWidth
       this.height = video.videoHeight
-      this.aspectRatioPercentage = `${(this.height / this.width) * 100}%`
+      this.aspectRatio = this.height / this.width
     },
     play (e) {
       if (e) e.stopPropagation()
@@ -193,7 +193,7 @@ export default {
     computedWrapStyles () {
       return (this.cover)
         ? Object.assign({}, videoWrapInnerStyles, mediaCoveringStyles)
-        : { paddingBottom: this.aspectRatioPercentage, ...videoWrapInnerStyles }
+        : { paddingBottom: `${this.aspectRatio * 100}%`, marginTop: `${(1 - this.aspectRatio) / 2 * 100}%`, ...videoWrapInnerStyles }
     },
     computedVideoStyles () {
       const cover = Object.assign({}, videoStyles, mediaCoveringStyles)


### PR DESCRIPTION
Great package. It worked perfectly for my needs. The only thing I needed to have the package do is center the video vertically in the container. I've added another prop `square` which will add margin to the top of the video to make the video centered in a square container. 